### PR TITLE
CSI Userland - cp EXAMPLE vagrant files if vagrant.yaml does not exis…

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Not Quite Available - Coming Soon
 It's wise to rebuild csi often as this repo has numerous releases/week (unless you're in the Kali box, then it's handled for you daily in the Jenkins job called, "selfupdate-csi":
   ```
   $ /csi/vagrant/provisioners/csi.sh && csi
-  csi[v0.3.614]:001 >>> CSI.help
+  csi[v0.3.615]:001 >>> CSI.help
   ```
 
 

--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ fi
 vagrant plugin install vagrant-reload
 
 cd /csi && cat ./vagrant_rsync_userland_configs.lst | while read userland_config; do
-  if [[ ! -e $userland_config ]]; then
+  if [[ `basename ${userland_config}` == 'vagrant.yaml' && ! -e $userland_config ]]; then
     cp $userland_config.EXAMPLE $userland_config
   fi
 done

--- a/lib/csi/version.rb
+++ b/lib/csi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CSI
-  VERSION = '0.3.614'
+  VERSION = '0.3.615'
 end


### PR DESCRIPTION
…t in respective userland folder per vagrant_rsync_userland_configs.lst in order to get through an installation - slight_tewak to omit files other than vagrant.yaml