### PR TITLE
CSI::Plugins::Metasploit - remove redundant method call #console_exec…

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Not Quite Available - Coming Soon
 It's wise to rebuild csi often as this repo has numerous releases/week (unless you're in the Kali box, then it's handled for you daily in the Jenkins job called, "selfupdate-csi":
   ```
   $ /csi/vagrant/provisioners/csi.sh && csi
-  csi[v0.3.634]:001 >>> CSI.help
+  csi[v0.3.635]:001 >>> CSI.help
   ```
 
 

--- a/lib/csi/plugins/metasploit.rb
+++ b/lib/csi/plugins/metasploit.rb
@@ -42,11 +42,11 @@ module CSI
       end
 
       # Supported Method Parameters::
-      # console_obj = CSI::Plugins::Metasploit.console_exec(
+      # console_obj = CSI::Plugins::Metasploit.queue_console_cmd(
       #   console_obj: 'required - console_obj object returned from #connect method',
-      #   cmd: 'required - msfconsole command'
+      #   cmd: 'required - msfconsole command string or array of strings'
       # )
-      def self.console_exec(opts = {})
+      private_class_method def self.queue_console_cmd(opts = {})
         console_obj = opts[:console_obj]
         cmd = opts[:cmd].to_s.strip.chomp.scrub
 
@@ -78,10 +78,33 @@ module CSI
       end
 
       # Supported Method Parameters::
+      # console_obj = CSI::Plugins::Metasploit.console_exec(
+      #   console_obj: 'required - console_obj object returned from #connect method',
+      #   cmd: 'required - msfconsole command string or array of strings'
+      # )
+      public_class_method def self.console_exec(opts = {})
+        console_obj = opts[:console_obj]
+        cmd = opts[:cmd].to_s.strip.chomp.scrub
+
+        case cmd.class
+        when String
+          console_obj = queue_console_cmd(console_obj: console_obj, cmd: cmd)
+        when Array
+          cmd.each { |this_cmd| console_obj = queue_console_cmd(console_obj: console_obj, cmd: this_cmd) }
+        else
+          raise 'ERROR: cmd parameter must be a String or Array object'
+        end
+
+        return console_obj
+      rescue => e
+        raise e
+      end
+
+      # Supported Method Parameters::
       # console_obj = CSI::Plugins::Metasploit.disconnect(
       #   console_obj: 'required - console_obj returned from #console_exec method to terminate'
       # )
-      def self.disconnect(opts = {})
+      public_class_method def self.disconnect(opts = {})
         console_obj = opts[:console_obj]
         msfrpcd_conn = console_obj[:msfrpcd_conn]
         console_id = console_obj[:session][:id]
@@ -113,7 +136,7 @@ module CSI
 
           console_obj = #{self}.console_exec(
             console_obj: 'required - msfrpcd_conn object returned from #connect method',
-            cmd: 'required - msfconsole command'
+            cmd: 'required - msfconsole command string or array of strings'
           )
 
           console_obj = #{self}.disconnect(

--- a/lib/csi/version.rb
+++ b/lib/csi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CSI
-  VERSION = '0.3.634'
+  VERSION = '0.3.635'
 end


### PR DESCRIPTION
… by allowing cmd parameter to be a string or array or strings - See https://gist.github.com/ninp0/6b9556e7799df44f44605acf7887b974 for example