### PR TITLE
.rubocop.yml - Disable caching for AllCops to avoid symlink warning m…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 inherit_from: .rubocop_todo.yml
-AllCops:
+AllCops: 
+  UseCache: false
   NewCops: enable
 Layout:
   Max: 3000

--- a/lib/csi/version.rb
+++ b/lib/csi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CSI
-  VERSION = '0.4.22'
+  VERSION = '0.4.23'
 end


### PR DESCRIPTION
…essages